### PR TITLE
Add compatibility for cp65001 encoding in cmd.exe in Windows

### DIFF
--- a/git_miner.py
+++ b/git_miner.py
@@ -6,6 +6,9 @@ from lxml import html
 import os
 os.system('cls' if os.name == 'nt' else 'clear')
 
+import codecs
+codecs.register(lambda name: codecs.lookup('utf-8') if name == 'cp65001' else None)
+
 class frescurinha:
     HELP = '\033[1;36m'
     OKBLUE = '\033[1;94m'


### PR DESCRIPTION
Cheers for great repo first of all!

The query

`python git_miner.py -q 'filename:wp-config extension:php FTP_HOST in:file ' -m wordpress -o result.txt`

generates `LookupError` for the first query result, in `parseCode` function, when run under Windows in cmd.exe set up with cp65001 (UTF-8 of Windows) encoding. 

The PR fixes the issue.